### PR TITLE
moved to unittest and squashed complex warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,3 @@ Currently the end-user is expected to save the outputs. But could be good to sav
 
 ## PCA, MDS, PCoA
 PCoA returns the same results as lostruct's MDS implementation (cmdscale). In the example Jupyter notebook you can see the correlation is R =~ 0.998. Some examples of other methods of clustering / looking at differences are included in the notebook.
-
-## Casting complex values to real discards the imaginary part
-This is fine.
-

--- a/README.md
+++ b/README.md
@@ -38,24 +38,21 @@ Python >= 3.6 (may work with older versions). Developed on Python 3.8.5
 
 * numba
 * numpy
-* pandas
-* scipy
-* skbio
-* sklearn
 * cyvcf2
 
-CyVCF2 requires zlib-dev, libbz2-dev, libcurl-dev, liblzma-dev, and probably others
-
-Easiest to install all of these through conda
+CyVCF2 requires zlib-dev, libbz2-dev, libcurl-dev, liblzma-dev; numa requires libllvm.
+These may be installed with `conda` or `pip`, e.g. by running `pip install -r requirements.txt`.
 
 # Tests
 
 Tests were derived from [Medicago HapMap data](http://www.medicagohapmap.org/downloads/Mt40/Mt4.0_HapMap_README.pdf). While the software had high correlation with lostruct R the values were determined. If values begin to deviate from the method these tests will now fail.
 
-To run tests simply use:
-```py.test```
+To run tests simply do:
+```
+python -m nose
+```
 
-You may need to preinstall ```pip install pytest```
+The tests furthermore require `unittest` and `scikit-bio` (and, `nose` to run them this way).
 
 ## TOX
 Tox allows you run tests with multiple versions of the python interpreter in venvs. It is best to use pyenv to install multiple versions python to run before submitting pull requests to be certain tests complete successfully across all versions.

--- a/lostructpy/lostruct.py
+++ b/lostructpy/lostruct.py
@@ -71,16 +71,10 @@ def cov_pca(snps,k,w=1):
     #first_return_arg = np.sum(np.power(covmat, 2).flatten())
     vals, vectors = np.linalg.eig(covmat)
 
-    eigenvecs = list()
-    for i in range(k):
-        eigenvecs.append(vectors[:,i])
-
-    #eigenvals = vals[0:k]
-    #eigenvals.astype(np.float64)
-
-    # assert(np.array_equal(eigenvecs, vectors[:k]))
+    vals = vals[:k].real.astype(np.float64)
+    vectors = vectors[:,:k].T.real.astype(np.float64)
     
-    return covmat, total_variance, vals[0:k], np.asarray(eigenvecs, dtype=np.float64)
+    return covmat, total_variance, vals, vectors
 
 # I think this became a wrapper function for cov_pca...
 def eigen_windows(snps, k, w):
@@ -101,7 +95,7 @@ def get_pc_dists(windows):
     comparison = np.zeros((n, n), dtype=np.float64)
     upper_triangle = zip(*np.triu_indices(n, k=1))
     
-    vals = vals.astype(np.float64)
+    vals = vals.real.astype(np.float64)
 
     for i,j in upper_triangle:
         comparison[i,j] = dist_sq_from_pcs(vals[i], vals[j], windows[i][3], windows[j][3])

--- a/tests/test_fns.py
+++ b/tests/test_fns.py
@@ -2,109 +2,114 @@ import lostructpy as ls
 import cyvcf2 as vcf
 import sparse
 import numpy as np
-from itertools import islice
-from skbio.stats.ordination import pcoa
+import itertools
+import skbio.stats.ordination
+import unittest
 
 # TODO: Rewrite this to make early VCF parsing and PCA stuff one-time run
 
 # This codeblock taken from https://docs.python.org/3/library/itertools.html
 def take(n, iterable):
     "Return first n items of the iterable as a list"
-    return list(islice(iterable, n))
+    return list(itertools.islice(iterable, n))
 #...
 
 vcf_file = "chr1-filtered.vcf.gz"
 
-def test_readvcf():
-    assert(ls.get_landmarks(vcf_file)[0] == "chl_Mt")
-    assert(ls.get_samples(vcf_file)[0] == "HM017-I")
-    assert(len(ls.get_samples(vcf_file)) == 50)
+class TestVcf(unittest.TestCase):
 
-def test_partitionall():
-    assert(len(list(ls.partition_all(3, range(10)))[3]) == 1)
+    def test_readvcf(self):
+        self.assertEqual(ls.get_landmarks(vcf_file)[0], "chl_Mt")
+        self.assertEqual(ls.get_samples(vcf_file)[0], "HM017-I")
+        self.assertEqual(len(ls.get_samples(vcf_file)), 50)
 
-def test_getsnps():
-    record = next(ls.get_snps(vcf_file, "chr1"))
-    assert(isinstance(record, vcf.Variant))
+    def test_partitionall(self):
+        self.assertEqual(len(list(ls.partition_all(3, range(10)))[3]), 1)
 
-def test_getgts():
-    record = next(ls.get_snps(vcf_file, "chr1"))
-    gts = ls.get_gts(record)
-    assert(gts.shape == (50,))
-    assert(gts[0] == 2.)
-    assert(gts[-1] == 2.)
+    def test_getsnps(self):
+        record = next(ls.get_snps(vcf_file, "chr1"))
+        self.assertTrue(isinstance(record, vcf.Variant))
 
-def test_parse_vcf():
-    windows, positions = ls.parse_vcf(vcf_file, "chr1", 99)
-    assert(len(windows) == 119)
-    assert(len(positions) == len(windows))
-    assert(positions[0][0] == 59864)
-    assert(isinstance(windows[0], sparse.COO))
+    def test_getgts(self):
+        record = next(ls.get_snps(vcf_file, "chr1"))
+        gts = ls.get_gts(record)
+        self.assertEqual(gts.shape, (50,))
+        self.assertEqual(gts[0], 2.)
+        self.assertEqual(gts[-1], 2.)
 
-error_tolerance = 0.00000001
+    def test_parse_vcf(self):
+        windows, positions = ls.parse_vcf(vcf_file, "chr1", 99)
+        self.assertEqual(len(windows), 119)
+        self.assertEqual(len(positions), len(windows))
+        self.assertEqual(positions[0][0], 59864)
+        self.assertTrue(isinstance(windows[0], sparse.COO))
 
-def test_cov_pca():
-    windows, _ = ls.parse_vcf(vcf_file, "chr1", 99)
-    covmat, total_variance, eigenvals, eigenvecs = ls.cov_pca(windows[0].todense(), 5, 1)
-    assert(np.abs(np.sum(covmat) - -0.4784263654778492) <= error_tolerance)
-    assert(np.abs(np.sum(total_variance) - 0.9265612493057297) <= error_tolerance)
-    assert(np.abs(np.sum(eigenvals) - 1.735862014813605) <= error_tolerance)
-    assert(np.abs(np.sum(eigenvecs) - 0.13157175919284625) <= error_tolerance)
+class TestCalculations(unittest.TestCase):
 
-def test_eigen_windows():
-    windows, _ = ls.parse_vcf(vcf_file, "chr1", 99)
-    covmat, total_variance, eigenvals, eigenvecs = ls.eigen_windows(windows[0], 5, 1)
-    assert(np.abs(np.sum(covmat) - -0.4784263654778492) <= error_tolerance)
-    assert(np.abs(np.sum(total_variance) - 0.9265612493057297) <= error_tolerance)
-    assert(np.abs(np.sum(eigenvals) - 1.735862014813605) <= error_tolerance)
-    assert(np.abs(np.sum(eigenvecs) - 0.13157175919284625) <= error_tolerance)
+    error_tolerance = 0.00000001
 
-def test_l1_norm():
-    windows, _ = ls.parse_vcf(vcf_file, "chr1", 99)
-    _, _, eigenvals, _ = ls.eigen_windows(windows[0], 5, 1)
-    assert(np.sum(ls.l1_norm(eigenvals)) == 5.0)
+    def test_cov_pca(self):
+        windows, _ = ls.parse_vcf(vcf_file, "chr1", 99)
+        covmat, total_variance, eigenvals, eigenvecs = ls.cov_pca(windows[0].todense(), 5, 1)
+        self.assertAlmostEqual(np.sum(covmat), -0.4784263654778492, delta=self.error_tolerance)
+        self.assertAlmostEqual(np.sum(total_variance), 0.9265612493057297, delta=self.error_tolerance)
+        self.assertAlmostEqual(np.sum(eigenvals), 1.735862014813605, delta=self.error_tolerance)
+        self.assertAlmostEqual(np.sum(eigenvecs), 0.13157175919284625, delta=self.error_tolerance)
 
-# Many of these tests are redundant, so this one won't be...
-# It also tests dist_sq_from_pcs so we won't test that separately...
-def test_get_pcs_dists():
-    windows, _ = ls.parse_vcf(vcf_file, "chr1", 99)
-    result = list()
-    for x in take(4, windows):
-        result.append(ls.eigen_windows(x, 10, 1))
-    result = np.vstack(result)
-    pc_dists = ls.get_pc_dists(result)
+    def test_eigen_windows(self):
+        windows, _ = ls.parse_vcf(vcf_file, "chr1", 99)
+        covmat, total_variance, eigenvals, eigenvecs = ls.eigen_windows(windows[0], 5, 1)
+        self.assertAlmostEqual(np.sum(covmat), -0.4784263654778492, delta=self.error_tolerance)
+        self.assertAlmostEqual(np.sum(total_variance), 0.9265612493057297, delta=self.error_tolerance)
+        self.assertAlmostEqual(np.sum(eigenvals), 1.735862014813605, delta=self.error_tolerance)
+        self.assertAlmostEqual(np.sum(eigenvecs), 0.13157175919284625, delta=self.error_tolerance)
 
-    assert(pc_dists[0][0] == 0.0)
-    assert(np.abs(pc_dists[0][3] - 0.30474948474286145) <= error_tolerance)
+    def test_l1_norm(self):
+        windows, _ = ls.parse_vcf(vcf_file, "chr1", 99)
+        _, _, eigenvals, _ = ls.eigen_windows(windows[0], 5, 1)
+        self.assertEqual(np.sum(ls.l1_norm(eigenvals)), 5.0)
 
-def test_compare_to_rcode():
-    windows, _ = ls.parse_vcf(vcf_file, "chr1", 95)
-    covmat, total_variance, eigenvals, eigenvecs = ls.cov_pca(windows[0].todense(), 10, 1)
+    # Many of these tests are redundant, so this one won't be...
+    # It also tests dist_sq_from_pcs so we won't test that separately...
+    def test_get_pcs_dists(self):
+        windows, _ = ls.parse_vcf(vcf_file, "chr1", 99)
+        result = list()
+        for x in take(4, windows):
+            result.append(ls.eigen_windows(x, 10, 1))
+        result = np.vstack(result)
+        pc_dists = ls.get_pc_dists(result)
 
-    results = np.loadtxt("lostruct-results/chr1.filtered.pca.csv", 
-                            delimiter=",", 
-                            skiprows=1)
+        self.assertEqual(pc_dists[0][0], 0.0)
+        self.assertAlmostEqual(pc_dists[0][3], 0.30474948474286145, delta=self.error_tolerance)
 
-    totalandvalsR = results[0][0:11]
-    totalandvalsPy = np.concatenate(([total_variance], eigenvals)),
-    # Comes out as 0.9999921929150888
-    assert(np.corrcoef(totalandvalsR, totalandvalsPy)[0][1] >= 0.99999)
+    def test_compare_to_rcode(self):
+        windows, _ = ls.parse_vcf(vcf_file, "chr1", 95)
+        covmat, total_variance, eigenvals, eigenvecs = ls.cov_pca(windows[0].todense(), 10, 1)
 
-    # Squared here, because signs are often opposite between the two analyses.
-    eigenvecsR = np.square(results[0][11:61])
-    eigenvecsPy = np.square(eigenvecs[0])
-    # Comes out as 0.9999921929150888
-    assert(np.corrcoef(eigenvecsR, eigenvecsPy)[0][1] >= 0.99999)
-    assert(covmat.shape == (50, 50))
+        results = np.loadtxt("lostruct-results/chr1.filtered.pca.csv", 
+                                delimiter=",", 
+                                skiprows=1)
 
-    mds_coords = np.loadtxt("lostruct-results/mds_coords.csv", 
-            delimiter=",", skiprows=1, usecols=[2])
+        totalandvalsR = results[0][0:11]
+        totalandvalsPy = np.concatenate(([total_variance], eigenvals)),
+        # Comes out as 0.9999921929150888
+        self.assertTrue(np.corrcoef(totalandvalsR, totalandvalsPy)[0][1] >= 0.99999)
 
-    result = list()
-    for x in windows:
-        result.append(ls.eigen_windows(x, 10, 1))
-    result = np.vstack(result)
-    pc_dists = ls.get_pc_dists(result)
-    mds = pcoa(pc_dists)
-    # Comes out as 0.9971509982243156
-    assert(np.corrcoef(mds.samples['PC1'], mds_coords)[0][1] >= 0.995)
+        # Squared here, because signs are often opposite between the two analyses.
+        eigenvecsR = np.square(results[0][11:61])
+        eigenvecsPy = np.square(eigenvecs[0])
+        # Comes out as 0.9999921929150888
+        self.assertTrue(np.corrcoef(eigenvecsR, eigenvecsPy)[0][1] >= 0.99999)
+        self.assertEqual(covmat.shape, (50, 50))
+
+        mds_coords = np.loadtxt("lostruct-results/mds_coords.csv", 
+                delimiter=",", skiprows=1, usecols=[2])
+
+        result = list()
+        for x in windows:
+            result.append(ls.eigen_windows(x, 10, 1))
+        result = np.vstack(result)
+        pc_dists = ls.get_pc_dists(result)
+        mds = skbio.stats.ordination.pcoa(pc_dists)
+        # Comes out as 0.9971509982243156
+        self.assertTrue(np.corrcoef(mds.samples['PC1'], mds_coords)[0][1] >= 0.995)


### PR DESCRIPTION
Here's the changes for `unittest`; running the tests is now `python -m nose -v`. Not too much boilerplate, I think?  What do you think?

I also sqaushed those warnings about complex numbers.